### PR TITLE
Add poker bot framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# Trading_Algo
-Pet Project Trading Algorithim
+# Poker Bot
+
+This repository contains a minimal framework for building a Texas Hold'em poker bot using
+computer vision and game-theoretic decision making. The project shows how to capture
+video frames, detect playing cards, maintain a structured game state, and select
+actions using a simplified Counterfactual Regret Minimization (CFR) trainer.
+
+## Structure
+
+```
+README.md               - This file
+poker_bot/
+    requirements.txt    - Python package requirements
+    vision.py           - Vision utilities (frame capture and card detection)
+    state.py            - Data structures representing game state
+    cfr.py              - Simplified CFR implementation
+    main.py             - Example integration loop
+```
+
+## Setup
+
+1. Install Python 3.10 or newer.
+2. Create a virtual environment and install requirements:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r poker_bot/requirements.txt
+```
+
+3. Set up OpenAI API credentials if you plan to use the vision API. The current
+   implementation includes a placeholder in `vision.py` where API calls should be
+   added.
+
+## Running
+
+The main entry point is `poker_bot/main.py`.
+
+```bash
+python poker_bot/main.py
+```
+
+By default, the script trains a simple CFR model and then enters an infinite loop
+where it captures frames, parses detections, and prints the chosen action every
+second. Replace the placeholder detection logic with calls to your computer vision
+backend to make it fully functional.
+
+## Evaluating the Bot
+
+To evaluate performance, you can pit the bot against baseline strategies such as
+random play or simple rule-based opponents. Compare win rates over many hands and
+observe decision quality in various situations. For rigorous evaluation, integrate
+a poker simulator that supports automated play and record statistics like expected
+value, fold equity, and exploitability.

--- a/poker_bot/cfr.py
+++ b/poker_bot/cfr.py
@@ -1,0 +1,56 @@
+"""Simplified Counterfactual Regret Minimization implementation."""
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from typing import Dict, Tuple
+
+Action = str
+
+
+class CFRNode:
+    def __init__(self, actions: Tuple[Action, ...]):
+        self.actions = actions
+        self.regret_sum = defaultdict(float)
+        self.strategy_sum = defaultdict(float)
+
+    def get_strategy(self) -> Dict[Action, float]:
+        positive_regrets = [max(0.0, self.regret_sum[a]) for a in self.actions]
+        normalizing_sum = sum(positive_regrets)
+        if normalizing_sum > 0:
+            strategy = {a: r / normalizing_sum for a, r in zip(self.actions, positive_regrets)}
+        else:
+            uniform_prob = 1.0 / len(self.actions)
+            strategy = {a: uniform_prob for a in self.actions}
+        for a, p in strategy.items():
+            self.strategy_sum[a] += p
+        return strategy
+
+    def get_average_strategy(self) -> Dict[Action, float]:
+        normalizing_sum = sum(self.strategy_sum.values())
+        if normalizing_sum == 0:
+            return {a: 1.0 / len(self.actions) for a in self.actions}
+        return {a: self.strategy_sum[a] / normalizing_sum for a in self.actions}
+
+
+class CFRTrainer:
+    def __init__(self):
+        self.node = CFRNode(actions=("fold", "call", "raise"))
+
+    def train(self, iterations: int = 1000):
+        for _ in range(iterations):
+            self.cfr()
+
+    def cfr(self):
+        strategy = self.node.get_strategy()
+        # Placeholder: compute utilities of actions and update regrets
+        # In a real system, this would traverse the game tree.
+        util = random.random()
+        for a in self.node.actions:
+            regret = util - random.random()
+            self.node.regret_sum[a] += regret
+
+    def get_action(self) -> Action:
+        strategy = self.node.get_average_strategy()
+        actions, probs = zip(*strategy.items())
+        return random.choices(actions, probs)[0]

--- a/poker_bot/main.py
+++ b/poker_bot/main.py
@@ -1,0 +1,36 @@
+"""Entry point for the poker bot."""
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from vision import grab_frame, detect_cards
+from state import GameState, PlayerState
+from cfr import CFRTrainer
+
+
+def setup_game() -> GameState:
+    state = GameState()
+    # Example: two players heads-up
+    state.players["player1"] = PlayerState(position="SB", stack=1000)
+    state.players["player2"] = PlayerState(position="BB", stack=1000)
+    return state
+
+
+def main(video_source: int | str = 0, iterations: int = 1000):
+    game_state = setup_game()
+    trainer = CFRTrainer()
+    trainer.train(iterations)
+
+    while True:
+        frame = grab_frame(video_source)
+        detection = detect_cards(frame)
+        game_state.update_from_detection(detection)
+        action = trainer.get_action()
+        print(f"Bot action: {action}")
+        game_state.record_action("bot", action)
+        time.sleep(1)  # simulate delay between actions
+
+
+if __name__ == "__main__":
+    main()

--- a/poker_bot/requirements.txt
+++ b/poker_bot/requirements.txt
@@ -1,0 +1,3 @@
+openai
+opencv-python
+numpy

--- a/poker_bot/state.py
+++ b/poker_bot/state.py
@@ -1,0 +1,35 @@
+"""Game state representation for Texas Hold'em."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple, Dict
+
+Card = Tuple[str, str]  # (rank, suit)
+
+
+@dataclass
+class PlayerState:
+    position: str
+    stack: int
+    hole_cards: List[Card] = field(default_factory=list)
+    bet: int = 0
+
+
+@dataclass
+class GameState:
+    players: Dict[str, PlayerState] = field(default_factory=dict)
+    community_cards: List[Card] = field(default_factory=list)
+    pot: int = 0
+    betting_history: List[str] = field(default_factory=list)
+
+    def update_from_detection(self, detection: Dict[str, List[Card]]):
+        """Update game state from vision detection output."""
+        for key, cards in detection.items():
+            if key == "community":
+                self.community_cards = cards
+            elif key in self.players:
+                self.players[key].hole_cards = cards
+
+    def record_action(self, player: str, action: str):
+        """Record a player's action."""
+        self.betting_history.append(f"{player}:{action}")

--- a/poker_bot/vision.py
+++ b/poker_bot/vision.py
@@ -1,0 +1,46 @@
+"""Vision module for detecting playing cards and table elements using OpenAI's vision API.
+This module contains utility functions to grab frames from a webcam or a video file
+and send them to the model for detection.
+The detection step is stubbed for demonstration purposes.
+"""
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing import List, Dict, Tuple
+
+
+def grab_frame(source: int | str = 0) -> np.ndarray:
+    """Grab a single frame from a video source.
+
+    Args:
+        source: Index of the webcam or path to a video file.
+    Returns:
+        The captured frame in BGR format.
+    """
+    cap = cv2.VideoCapture(source)
+    ret, frame = cap.read()
+    cap.release()
+    if not ret:
+        raise RuntimeError("Failed to capture frame")
+    return frame
+
+
+def detect_cards(frame: np.ndarray) -> Dict[str, List[Tuple[str, str]]]:
+    """Detect cards and table elements in a frame using OpenAI's vision API.
+
+    This is a placeholder implementation. In a real system, the frame would be
+    encoded and sent to OpenAI's vision endpoint, which would return structured
+    information about card ranks and suits, chip stacks, and other elements.
+
+    Args:
+        frame: An image represented as a NumPy array.
+
+    Returns:
+        A dictionary mapping element types ("community", "player1", etc.) to a
+        list of tuples (rank, suit).
+    """
+    # TODO: integrate with OpenAI vision API.
+    # For now return an empty structure.
+    return {}
+


### PR DESCRIPTION
## Summary
- introduce `poker_bot` module with card detection stub, game state, CFR strategy, and main loop
- update README with setup and usage instructions

## Testing
- `python -m py_compile poker_bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c1836c45083338a72ab75f5201174